### PR TITLE
Add some docs, but the SetCookie and Cookie are a bit not clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,71 @@ FIG Cookies
 ===========
 
 Managing Cookies for PSR-7 Requests and Responses.
+
+# Accessing cookies from Request
+
+```php
+use Dflydev\FigCookies\Cookies;
+
+// $request = a psr7request;
+$cookies = Cookies::fromRequest($request);
+```
+
+## Check a cookie exists
+
+You can check whether a cookie by name exists via `has` method which returns `bool`.
+
+```php
+$cookies->has('name');
+```
+
+## Get cookie
+
+You can get a `Cookie` object via `get` method.
+
+```php
+$cookie = $cookies->get('name');
+```
+
+This will return a `Dflydev\FigCookies\Cookie` object via which you can get
+name, value etc via `getName()` and `getValue()` respectively.
+
+## Change cookie value
+
+You can change the value of a cookie via `withValue` method.
+
+```php
+$cookie->withValue('some value');
+```
+
+or alternatively you can create a fresh cookie object via
+
+```php
+use Dflydev\FigCookies\Cookie;
+
+$cookie = new Cookie('name');
+// or
+// $cookie = Cookie::create('name');
+
+$cookie->withValue('some value');
+```
+
+## Setting cookie to header
+
+```php
+use Dflydev\FigCookies\SetCookie;
+use Dflydev\FigCookies\Cookies;
+
+// $request = a psr7request
+
+$cookie = SetCookie::create('lu')
+    ->withValue('Rg3vHJZnehYLjVg7qi3bZjzg')
+    ->withExpires('Tue, 15-Jan-2013 21:47:38 GMT')
+    ->withMaxAge(500)
+    ->withPath('/')
+    ->withDomain('.example.com')
+    ->withSecure(true)
+    ->withHttpOnly(true);
+
+$request = $request->withHeader(Cookies::COOKIE_HEADER, $cookie->__toString());
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $cookie->withValue('some value');
 use Dflydev\FigCookies\SetCookie;
 use Dflydev\FigCookies\Cookies;
 
-// $request = a psr7request
+// $response = a psr7response
 
 $cookie = SetCookie::create('lu')
     ->withValue('Rg3vHJZnehYLjVg7qi3bZjzg')
@@ -68,5 +68,5 @@ $cookie = SetCookie::create('lu')
     ->withSecure(true)
     ->withHttpOnly(true);
 
-$request = $request->withHeader(Cookies::COOKIE_HEADER, $cookie->__toString());
+$response = $response->withHeader(Cookies::COOKIE_HEADER, $cookie->__toString());
 ```


### PR DESCRIPTION
Hi @simensen , 

I started to create some docs for the Readme. Somethings that came into my mind are 

1 ) There is a Cookies class 
2 ) Which contains collection of Cookie objects.
3 ) Now Cookies class have a method to convert them and attach to PSR 7 Requests.
4 ) There is a SetCookie class which have some what similarities with that of setcookie method of php. 

May be the purpose of Cookies is just to read and `SetCookies` is what we need to make use of when we need to send to response ?

Thank you