### PR TITLE
Add shortcut methods for long-living and expiring cookies

### DIFF
--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -165,6 +165,29 @@ class SetCookie
         return new static($name, $value);
     }
 
+    /**
+     * Create a cookie that lives "forever" (for five years).
+     *
+     * @param string $name
+     * @param string $value
+     * @return SetCookie
+     */
+    public static function forever($name, $value = null)
+    {
+        return static::create($name, $value)->withExpires(new DateTime('+5 years'));
+    }
+
+    /**
+     * Create an expired cookie.
+     *
+     * @param string $name
+     * @return SetCookie
+     */
+    public static function forget($name)
+    {
+        return static::create($name)->withExpires(new DateTime('-5 years'));
+    }
+
     public static function fromSetCookieString($string)
     {
         $rawAttributes = StringUtil::splitOnAttributeDelimiter($string);


### PR DESCRIPTION
With this, we can do stuff like the following:

~~~php
// Keep a user preference for a very long time (5 years)
SetCookie::forever('colorpref', 'green');

// Expire the named cookie
SetCookie::forget('rememberme');
~~~