### PR TITLE
Add shortcut methods for long-lived / expiring cookies

### DIFF
--- a/src/Dflydev/FigCookies/FigResponseCookies.php
+++ b/src/Dflydev/FigCookies/FigResponseCookies.php
@@ -40,6 +40,17 @@ class FigResponseCookies
 
     /**
      * @param ResponseInterface $response
+     * @param string $cookieName
+     *
+     * @return ResponseInterface
+     */
+    public static function expire(ResponseInterface $response, $cookieName)
+    {
+        return static::set($response, SetCookie::createExpired($cookieName));
+    }
+
+    /**
+     * @param ResponseInterface $response
      * @param string $name
      * @param callable $modify
      *

--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -99,6 +99,16 @@ class SetCookie
         return $clone;
     }
 
+    public function rememberForever()
+    {
+        return $this->withExpires(new DateTime('+5 years'));
+    }
+
+    public function expire()
+    {
+        return $this->withExpires(new DateTime('-5 years'));
+    }
+
     public function withMaxAge($maxAge = null)
     {
         $clone = clone($this);
@@ -163,6 +173,16 @@ class SetCookie
     public static function create($name, $value = null)
     {
         return new static($name, $value);
+    }
+
+    public static function createRememberedForever($name, $value = null)
+    {
+        return static::create($name, $value)->rememberForever();
+    }
+
+    public static function createExpired($name)
+    {
+        return static::create($name)->expire();
     }
 
     public static function fromSetCookieString($string)

--- a/tests/Dflydev/FigCookies/SetCookieTest.php
+++ b/tests/Dflydev/FigCookies/SetCookieTest.php
@@ -110,4 +110,25 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function it_expires_cookies()
+    {
+        $setCookie = SetCookie::createExpired('expire_immediately');
+
+        $this->assertLessThan(time(), $setCookie->getExpires());
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_long_living_cookies()
+    {
+        $setCookie = SetCookie::createRememberedForever('remember_forever');
+
+        $fourYearsFromNow = (new \DateTime('+4 years'))->getTimestamp();
+        $this->assertGreaterThan($fourYearsFromNow, $setCookie->getExpires());
+    }
 }


### PR DESCRIPTION
Second shot at this after #4.

I went with `expired` instead of `forgotten`, because that sounded nicer to me. I'll change it back if you disagree.

I also did not add a `rememberForever` shortcut to the `FigResponseCookies` facade. The one you suggested (`FigResponseCookies::rememberForever('rememberme')`) did not make sense to me, as you'd still want to provide content for these cookies. Also, you mentioned earlier that you were unsure about whether that would need a method in the facade. Given that we now have `->rememberForever()` on `SetCookie` instances, that should do the trick. Again, I'll honor your wishes if you prefer something else.

Last question:
Would monsieur like some tests with that src? ;)
(If so, please hint at what exactly you'd like to see tested.)