### PR TITLE
Rename Forget a Response Cookie to Expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ use Dflydev\FigCookies\FigResponseCookies;
 $response = FigResponseCookies::remove($response, 'theme');
 ```
 
-#### Forget a Response Cookie
+#### Expire a Response Cookie
 
 The `expire` method sets a cookie with an expiry date in the far past. This
 causes the client to remove the cookie.


### PR DESCRIPTION
@franzliedke was mentioning it is good to keep expire than forget for the header. 

Discussion over https://github.com/dflydev/dflydev-fig-cookies/pull/15/files/ec5a325e1d6b048e08a2d3bc754e2863ad66fbf7#r73331400

@simensen if you think so, please merge.

Thank you.