### PR TITLE
Add gitattributes to exclude files and folders from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.scrutinizer.yml
-.travis.yml
-phpunit.xml.dist
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml
+.travis.yml
+phpunit.xml.dist


### PR DESCRIPTION
Added .gitattributes to exclude the tests on export - e.g. when pulled in via composer.

I've also included the following files which are not required:

`.gitattributes`, `.gitignore`, `.scrutinizer.yml`, `.travis.yml`, `phpunit.xml.dist`
