### PR TITLE
added withUrlEncode function

### DIFF
--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -15,6 +15,7 @@ class SetCookie
     private $domain;
     private $secure = false;
     private $httpOnly = false;
+    private $urlEncode = false;
 
     private function __construct($name, $value = null)
     {
@@ -153,13 +154,28 @@ class SetCookie
 
         return $clone;
     }
+    
+    public function withUrlEncode($urlEncode = null)
+    {
+        $clone = clone($this);
+
+        $clone->urlEncode = $urlEncode;
+
+        return $clone;
+    }
 
     public function __toString()
     {
-        $cookieStringParts = [
-            urlencode($this->name).'='.urlencode($this->value),
-        ];
-
+        if($this->urlEncode){
+            $cookieStringParts = [
+                urlencode($this->name).'='.urlencode($this->value),
+            ];
+        }else{
+            $cookieStringParts = [
+                $this->name.'='.$this->value,
+            ];
+        }
+        
         $cookieStringParts = $this->appendFormattedDomainPartIfSet($cookieStringParts);
         $cookieStringParts = $this->appendFormattedPathPartIfSet($cookieStringParts);
         $cookieStringParts = $this->appendFormattedExpiresPartIfSet($cookieStringParts);


### PR DESCRIPTION
Added new option:
withUrlEncode(true);

This allows you to enable the php urlencod() on the cookie name and value if needed.  This was necessary as most of my cookies are base64 encoded for AWS CloudFront and the equals symbol.