### PR TITLE
allow NULL-valued and 0-valued Max-Age

### DIFF
--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -62,7 +62,7 @@ class SetCookie
         return $this->expires;
     }
 
-    public function getMaxAge() : int
+    public function getMaxAge() : ?int
     {
         return $this->maxAge;
     }

--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -151,7 +151,7 @@ class SetCookie
     {
         $clone = clone($this);
 
-        $clone->maxAge = (int) $maxAge;
+        $clone->maxAge = $maxAge;
 
         return $clone;
     }
@@ -349,7 +349,7 @@ class SetCookie
      */
     private function appendFormattedMaxAgePartIfSet(array $cookieStringParts) : array
     {
-        if ($this->maxAge) {
+        if (is_int($this->maxAge)) {
             $cookieStringParts[] = sprintf('Max-Age=%s', $this->maxAge);
         }
 

--- a/src/Dflydev/FigCookies/SetCookie.php
+++ b/src/Dflydev/FigCookies/SetCookie.php
@@ -28,8 +28,8 @@ class SetCookie
     private $value;
     /** @var int */
     private $expires = 0;
-    /** @var int */
-    private $maxAge = 0;
+    /** @var int|null */
+    private $maxAge = null;
     /** @var string|null */
     private $path;
     /** @var string|null */

--- a/tests/Dflydev/FigCookies/SetCookieTest.php
+++ b/tests/Dflydev/FigCookies/SetCookieTest.php
@@ -140,6 +140,20 @@ class SetCookieTest extends TestCase
                          ->withHttpOnly(true)
                          ->withSameSite(SameSite::lax()),
             ],
+            [
+                'lu=Rg3vHJZnehYLjVg7qi3bZjzg; Path=/; Max-Age=0',
+                SetCookie::create('lu')
+                         ->withValue('Rg3vHJZnehYLjVg7qi3bZjzg')
+                         ->withMaxAge(0)
+                         ->withPath('/'),
+            ],
+            [
+                'lu=Rg3vHJZnehYLjVg7qi3bZjzg; Path=/',
+                SetCookie::create('lu')
+                         ->withValue('Rg3vHJZnehYLjVg7qi3bZjzg')
+                         ->withMaxAge(null)
+                         ->withPath('/'),
+            ],
         ];
     }
 


### PR DESCRIPTION
- a `0` value will make the cookie to expire immediately
- a `NULL' value will remove the Max-Age part form the header line

https://github.com/dflydev/dflydev-fig-cookies/issues/30