### PR TITLE
Fix markdown link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@ All notable changes to this project will be documented in this file, in reverse 
     [BC] CHANGED: The return type of Dflydev\FigCookies\Cookies::fromRequest() changed from no type to Dflydev\FigCookies\Cookies
     ```
     
-- [#31](https://github.com/dflydev/dflydev-fig-cookies/pull/32) A new abstraction was
+- [#31](https://github.com/dflydev/dflydev-fig-cookies/pull/31) A new abstraction was
   introduced to support `SameSite=Lax` and `SameSite=Strict` `Set-Cookie` header modifiers.
 
 ### Deprecated


### PR DESCRIPTION
Hi, I was reviewing some updates to this package that dependabot had provided me and found that I think this URL is incorrect. There are others in the CHANGELOG that are also incorrect but I'm not entirely sure in which way they are incorrect so I took a guess.

Let me know if they need changing again.