### PR TITLE
Added support for SameSite=None. Updated tests.

### DIFF
--- a/src/Dflydev/FigCookies/Modifier/SameSite.php
+++ b/src/Dflydev/FigCookies/Modifier/SameSite.php
@@ -9,22 +9,34 @@ use function strtolower;
 
 final class SameSite
 {
-    /** @var bool */
-    private $strict;
+    /**
+     * The possible string values of the SameSite setting
+     */
+    private const STRICT = 'Strict';
+    private const LAX    = 'Lax';
+    private const NONE   = 'None';
 
-    private function __construct(bool $strict)
+    /** @var string */
+    private $value;
+
+    private function __construct(string $value)
     {
-        $this->strict = $strict;
+        $this->value = $value;
     }
 
     public static function strict() : self
     {
-        return new self(true);
+        return new self(self::STRICT);
     }
 
     public static function lax() : self
     {
-        return new self(false);
+        return new self(self::LAX);
+    }
+
+    public static function none() : self
+    {
+        return new self(self::NONE);
     }
 
     /**
@@ -42,14 +54,18 @@ final class SameSite
             return self::lax();
         }
 
+        if ($lowerCaseSite === 'none') {
+            return self::none();
+        }
+
         throw new \InvalidArgumentException(sprintf(
-            'Expected modifier value to be either "strict" or "lax", "%s" given',
+            'Expected modifier value to be either "strict", "lax", or "none", "%s" given',
             $sameSite
         ));
     }
 
     public function asString() : string
     {
-        return 'SameSite=' . ($this->strict ? 'Strict' : 'Lax');
+        return 'SameSite=' . $this->value;
     }
 }

--- a/tests/Dflydev/FigCookies/Modifier/SameSiteTest.php
+++ b/tests/Dflydev/FigCookies/Modifier/SameSiteTest.php
@@ -33,9 +33,21 @@ final class SameSiteTest extends TestCase
     }
 
     /** @test */
-    public function lax_and_strict_are_different() : void
+    public function it_can_be_a_None_SameSite_modifier() : void
+    {
+        $none = SameSite::none();
+
+        self::assertInstanceOf('Dflydev\FigCookies\Modifier\SameSite', $none);
+        self::assertSame('SameSite=None', $none->asString());
+        self::assertEquals(SameSite::none(), $none, 'Multiple instances are equivalent');
+    }
+
+    /** @test */
+    public function lax_strict_and_none_are_different() : void
     {
         self::assertNotEquals(SameSite::lax(), SameSite::strict());
+        self::assertNotEquals(SameSite::lax(), SameSite::none());
+        self::assertNotEquals(SameSite::strict(), SameSite::none());
     }
 
     /** @test */
@@ -47,6 +59,9 @@ final class SameSiteTest extends TestCase
         self::assertEquals(SameSite::lax(), SameSite::fromString('Lax'));
         self::assertEquals(SameSite::lax(), SameSite::fromString('lax'));
         self::assertEquals(SameSite::lax(), SameSite::fromString('lAx'));
+        self::assertEquals(SameSite::none(), SameSite::fromString('None'));
+        self::assertEquals(SameSite::none(), SameSite::fromString('none'));
+        self::assertEquals(SameSite::none(), SameSite::fromString('nOnE'));
 
         $this->expectException(InvalidArgumentException::class);
 


### PR DESCRIPTION
This PR adds `None` as a possible value for the SameSite setting. [Per the spec](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00), `None` is a valid value and is needed when explicitly permitting cross-site cookie delivery.