### PR TITLE
Do not decode cookie names, just values

### DIFF
--- a/src/Dflydev/FigCookies/StringUtil.php
+++ b/src/Dflydev/FigCookies/StringUtil.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Dflydev\FigCookies;
 
 use function array_filter;
-use function array_map;
 use function assert;
 use function explode;
 use function is_array;
 use function preg_split;
+use function urldecode;
 
 class StringUtil
 {
@@ -27,8 +27,8 @@ class StringUtil
     public static function splitCookiePair(string $string) : array
     {
         $pairParts    = explode('=', $string, 2);
-        $pairParts[1] = $pairParts[1] ?? '';
+        $pairParts[1] = urldecode($pairParts[1]) ?? '';
 
-        return array_map('urldecode', $pairParts);
+        return $pairParts;
     }
 }

--- a/tests/Dflydev/FigCookies/CookieTest.php
+++ b/tests/Dflydev/FigCookies/CookieTest.php
@@ -52,7 +52,7 @@ class CookieTest extends TestCase
     {
         return [
             ['someCookie=something', 'someCookie', 'something'],
-            ['hello%3Dworld=how%22are%27you', 'hello=world', 'how"are\'you'],
+            ['hello%3Dworld=how%22are%27you', 'hello%3Dworld', 'how"are\'you'],
             ['empty=', 'empty', ''],
         ];
     }


### PR DESCRIPTION
Per CVE-2020-7070, reported to the PHP project at https://bugs.php.net/bug.php?id=79699, cookie names SHOULD NOT be urldecoded.  The cookie specification is not entirely clear on whether _names_ should be urldecoded, though it does indicate _values_ should be.  The behavior of PHP until that patch was made, and, in fact, several other languages/frameworks, such as Rack, was to urldecode the names as well.  However, this can lead to security implications when urlencoding is used to create key names with cookie prefixes such as `__Host-` and `__Secure-`, which are supposed to be controlled entirely by the browser, and which are only to be set when specific conditions are met.

This patch modifies the logic used to split cookie pairs (i.e., cookie name/value pairs).  Previously, it passed both values to `urldecode`; now it only passes the cookie value.
