### PR TITLE
Fix potential TypeError with malformed cookie

### DIFF
--- a/src/Dflydev/FigCookies/StringUtil.php
+++ b/src/Dflydev/FigCookies/StringUtil.php
@@ -27,7 +27,7 @@ class StringUtil
     public static function splitCookiePair(string $string) : array
     {
         $pairParts    = explode('=', $string, 2);
-        $pairParts[1] = urldecode($pairParts[1]) ?? '';
+        $pairParts[1] = urldecode($pairParts[1] ?? '');
 
         return $pairParts;
     }


### PR DESCRIPTION
Fixes https://github.com/dflydev/dflydev-fig-cookies/issues/41

Additionally, I believe that `urldecode` in this situation can never return NULL because we always pass string to it, and `urldecode` just passes the malformed string as-is.