### PR TITLE
CI: Fix fetch-depth for checkout action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
 
             - uses: shivammathur/setup-php@v2
               with:


### PR DESCRIPTION
Without this change, GitHub will only do a shallow clone. More version history is needed to do code coverage comparison with ocular, apparently.

As discussed in #45. Tested and seems to work.