### PR TITLE
Implement easy immutable object creation

### DIFF
--- a/tests/Dflydev/FigCookies/SetCookieTest.php
+++ b/tests/Dflydev/FigCookies/SetCookieTest.php
@@ -208,4 +208,116 @@ class SetCookieTest extends TestCase
 
         SetCookie::fromSetCookieString('');
     }
+
+    /**
+     * @param array<mixed> $config
+     *
+     * @test
+     * @dataProvider withConfigData
+     */
+    public function it_creates_withConfig(array $config, SetCookie $expected): void
+    {
+        $setCookie = SetCookie::create($config['name'])->withConfig($config);
+        self::assertEquals($expected, $setCookie);
+    }
+
+    /** @return array<mixed> */
+    public function withConfigData(): array
+    {
+        return [
+            [
+                [
+                    'name' => 'BZXLFIX',
+                    'value' => '6349705',
+                    'maxAge' => 60 * 5,
+                    'path' => '/',
+                    'domain' => '',
+                    'secure' => true,
+                    'httpOnly' => true,
+                    'sameSite' => 'strict',
+                ],
+                SetCookie::create('BZXLFIX', '6349705')
+                    ->withMaxAge(60 * 5)
+                    ->withPath('/')
+                    ->withDomain('')
+                    ->withSecure(true)
+                    ->withHttpOnly(true)
+                    ->withSameSite(SameSite::fromString('Strict')),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<mixed> $config
+     *
+     * @return void     *
+     *
+     * @test
+     * @dataProvider CreateFromConfigData
+     */
+    public function it_creates_fromConfig(array $config, SetCookie $expected): void
+    {
+        $setCookie = SetCookie::fromConfig($config);
+        self::assertEquals($expected, $setCookie);
+    }
+
+    /**
+     * @param array<mixed> $config
+     *
+     * @return void     *
+     *
+     * @test
+     * @dataProvider CreateFromConfigData
+     */
+    public function throws_invalidArgument_without_name(array $config): void
+    {
+        unset($config['name']);
+        $this->expectException(InvalidArgumentException::class);
+        $setCookie = SetCookie::fromConfig($config);
+    }
+
+    /** @return array<mixed> */
+    public function CreateFromConfigData(): array
+    {
+        return [
+            [
+                [
+                    'name' => 'LISA_',
+                    'value' => '6349705',
+                    'path' => '/',
+                    'domain' => 'example.com',
+                    'secure' => true,
+                    'httpOnly' => true,
+                    'expires' => 'Tue, 15-Jan-2013 21:47:38 GMT',
+                    'sameSite' => 'Lax',
+                ],
+                SetCookie::create('LISA_', '6349705')
+                    ->withExpires(1358286458)
+                    ->withSameSite(SameSite::fromString('lax'))
+                    ->withPath('/')
+                    ->withDomain('example.com')
+                    ->withSecure(true)
+                    ->withHttpOnly(true),
+            ],
+            [
+                [
+                    'name' => 'LISA_',
+                    'value' => '6349705',
+                    'expires' => 1358286458,
+                    'path' => '/',
+                    'domain' => 'example.com',
+                    'secure' => true,
+                    'httpOnly' => true,
+                    'sameSite' => 'NONE',
+                ],
+                SetCookie::create('LISA_', '6349705')
+                    ->withPath('/')
+                    ->withDomain('example.com')
+                    ->withSecure(true)
+                    ->withHttpOnly(true)
+                    ->withExpires('Tue, 15-Jan-2013 21:47:38 GMT')
+                    ->withSameSite(SameSite::fromString('none')),
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Since the point of immutable objects is to create them in a state that cannot be modified. Shouldn't it be possible to achieve the desired end-state without leaving a long trail of immutable objects in our wake?

This PR adds two methods to allow efficient immutable object creation by using configuration arrays. 
In essence, we get to the full state we need without chaining a lot of `->withSomeSetting($value)` calls.

The method `withConfig(array $config)` allows a bulk mutation of an existing SetCookie, e.g.

    $setCookie = SetCookie::create('lu')->withConfig($config);

The second addition is the method `fromConfig(array $config)` allows creating a new SetCookie with a minimal amount of cloning.

    $setCookie = SetCookie::fromConfig($config);  // truthfully, this is essentially a decoration of the first example

The following `$config` could be used for both examples.

$config = [
    'name' => 'lu',
    'value' => 'Rg3vHJZnehYLjVg7qi3bZjzg',
    'expires' => 'Tue, 15-Jan-2013 21:47:38 GMT',
    'maxAge' => 500,
    'path' => '/',
    'domain' => '.example.com',
    'secure' => true,
    'httpOnly' => true,
    'samesite' => 'lax'
];

I may not understand all I know about immutable objects. I look forward to any feedback offered.